### PR TITLE
feat: update to ilp-plugin-bells@7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "five-bells-routing": "~4.0.0",
     "five-bells-shared": "^18.3.0",
     "ilp-core": "~8.0.0",
-    "ilp-plugin-bells": "^6.0.0",
+    "ilp-plugin-bells": "^7.0.0",
     "ilp-plugin-virtual": "^5.0.0",
     "koa": "^1.0.0",
     "koa-bunyan-logger": "^1.3.0",


### PR DESCRIPTION
plugin bells now uses ledger metadata URLs to discover service locations

note this will not work with ledgers before 16.1.1 because of the bug
fixed in https://github.com/interledger/five-bells-ledger/commit/fd28a665cc35569a7cf562dc9996928a6a322ab8