### PR TITLE
fix: handle non-responsive peers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@ node_modules/
 /coverage
 /apidoc-out
 /integration-test
-*v8.log
+*.log
 /web/
 /.tags*

--- a/src/lib/route-broadcaster.js
+++ b/src/lib/route-broadcaster.js
@@ -83,7 +83,7 @@ class RouteBroadcaster {
       json: true
     }).then((res) => {
       if (res.statusCode !== 200) {
-        throw new Error('Unexpected status code: ' + res.statusCode)
+        log.error('Error broadcasting route to: ' + adjacentConnector, res.statusCode, res.body)
       }
     })
   }

--- a/test/routeBroadcasterSpec.js
+++ b/test/routeBroadcasterSpec.js
@@ -116,6 +116,28 @@ describe('RouteBroadcaster', function () {
     })
   })
 
+  it('should not throw an error even if the other connector does not respond', function * () {
+    this.core.getPlugin(ledgerA).getInfo =
+      this.core.getPlugin(ledgerC).getInfo =
+      function () {
+        return Promise.resolve({ connectors: [{connector: baseURI}] })
+      }
+    this.core.getPlugin(ledgerB).getInfo =
+      function () {
+        return Promise.resolve({
+          connectors: [
+            {connector: baseURI},
+            {connector: 'http://other-connector2.example'}
+          ]
+        })
+      }
+
+    nock('http://other-connector2.example').post('/routes').reply(404)
+
+    yield this.broadcaster.crawlLedgers()
+    yield this.broadcaster.broadcast()
+  })
+
   describe('_quoteToLocalRoute', function () {
     it('returns a Route', function * () {
       const route = yield this.broadcaster._quoteToLocalRoute({


### PR DESCRIPTION
don't throw an error when broadcasting route to peer fails