### PR TITLE
Feat: [BREAKING] improve PAIRS, LEDGERS, CREDENTIALS

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,31 +47,32 @@ npm start
 
 #### Trading
 
-* `CONNECTOR_LEDGERS` (default: `[]`) Ledgers where this connector has accounts. Used to auto-generate `CONNECTOR_PAIRS`.
-```js
-[
-  "USD@example.usd-ledger.",
-  "EUR@example.eur-ledger."
-]
-```
-* `CONNECTOR_CREDENTIALS` (default: `{}`) Connector's login credentials for various ledgers, ex.
+* `CONNECTOR_LEDGERS` (default: `{}`) Connector's login credentials for ledgers where it has accounts. Used to auto-generate `CONNECTOR_PAIRS`.
 ```js
 {
   // Using Basic Auth
-  "<ledger_address>": {
-    "account": "...",
-    "username": "...",
-    "password": "..."
-    "ca": "...", // Optional
+  "example.usd-ledger.": {
+    "currency": "USD", // asset on this ledger
+    "plugin": "ilp-plugin-bells", // module for this ledger plugin
+    "options": { // actual plugin options passed into plugin constructor
+      "account": "...",
+      "username": "...",
+      "password": "..."
+      "ca": "...", // Optional
+    }
   },
 
   // Using Client Certificate Auth
-  "<ledger_address_2>": {
-    "account": "...",
-    "username": "...",
-    "cert": "...",
-    "key": "...",
-    "ca": "...", // Optional
+  "example.eur-ledger.": {
+    "currency": "EUR",
+    "plugin": "ilp-plugin-bells",
+    "options": {
+      "account": "...",
+      "username": "...",
+      "cert": "...",
+      "key": "...",
+      "ca": "...", // Optional
+    }
   }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "eslint-config-standard": "^5.1.0",
     "eslint-plugin-promise": "^1.1.0",
     "eslint-plugin-standard": "^1.3.2",
-    "five-bells-integration-test": "^3.1.0",
+    "five-bells-integration-test": "^4.0.0",
     "istanbul": "^0.4.1",
     "mocha": "^2.3.2",
     "mock-require": "^1.3.0",

--- a/src/lib/core.js
+++ b/src/lib/core.js
@@ -11,17 +11,17 @@ module.exports = function (options) {
 
   const core = new ilpCore.Core({routingTables})
   Object.keys(config.ledgerCredentials).forEach((ledgerPrefix) => {
-    const creds = _.clone(config.ledgerCredentials[ledgerPrefix])
-    const store = creds.store && newSqliteStore(creds.store)
+    const creds = _.cloneDeep(config.ledgerCredentials[ledgerPrefix])
+    const store = creds.options.store && newSqliteStore(creds.options.store)
 
-    creds.prefix = ledgerPrefix
-    core.addClient(ledgerPrefix, new ilpCore.Client(Object.assign({}, creds, {
+    creds.options.prefix = ledgerPrefix
+    core.addClient(ledgerPrefix, new ilpCore.Client(Object.assign({}, creds.options, {
       debugReplyNotifications: config.features.debugReplyNotifications,
       connector: config.server.base_uri,
       // non JSON-stringifiable fields are prefixed with an underscore
-      _plugin: require('ilp-plugin-' + creds.type),
+      _plugin: require(creds.plugin),
       _store: store,
-      _log: makeLogger('plugin-' + creds.type)
+      _log: makeLogger(creds.plugin)
     })))
   })
   return core

--- a/src/lib/route-broadcaster.js
+++ b/src/lib/route-broadcaster.js
@@ -118,8 +118,8 @@ class RouteBroadcaster {
   }
 
   _tradingPairToLocalRoute (pair) {
-    const sourceLedger = pair[0].split('@')[1]
-    const destinationLedger = pair[1].split('@')[1]
+    const sourceLedger = pair[0].split('@').slice(1).join('@')
+    const destinationLedger = pair[1].split('@').slice(1).join('@')
     // TODO change the backend API to return curves, not points
     return co(function * () {
       const quote = yield this.backend.getQuote({

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -3,18 +3,19 @@
 const crypto = require('crypto')
 
 /**
- * Get all possible pair combinations from an array.
+ * Get all possible pair combinations from an array, order sensitive.
  *
  * Example:
  *   getPairs ([1, 2, 3, 4])
- *   // => [ [ 1, 2 ], [ 1, 3 ], [ 1, 4 ], [ 2, 3 ], [ 2, 4 ], [ 3, 4 ] ]
+ *   // => [ [ 1, 2 ], [ 1, 3 ], [ 1, 4 ], [ 2, 3 ], [ 2, 4 ], [ 3, 4 ],
+ *           [ 2, 1 ], [ 3, 1 ], [ 4, 1 ], [ 3, 2 ], [ 4, 2 ], [ 4, 3 ] ]
  *
  * @param {array} arr Input array
  * @return {array[]} Possible pairs
  */
 function getPairs (arr) {
   return arr.reduce((prev, cur, i) => (
-    prev.concat(arr.slice(i + 1).map((val) => [cur, val]))
+    [].concat.apply(prev, arr.slice(i + 1).map((val) => [[cur, val], [val, cur]]))
   ), [])
 }
 

--- a/test/data/ledgerCredentials.json
+++ b/test/data/ledgerCredentials.json
@@ -1,26 +1,38 @@
 {
   "cad-ledger.": {
-    "type": "mock",
-    "account": "http://cad-ledger.example:1000/accounts/mark",
-    "username": "mark",
-    "password": "mark"
+    "currency": "CAD",
+    "plugin": "ilp-plugin-mock",
+    "options": {
+      "account": "http://cad-ledger.example:1000/accounts/mark",
+      "username": "mark",
+      "password": "mark"
+    }
   },
   "usd-ledger.": {
-    "type": "mock",
-    "account": "http://usd-ledger.example/accounts/mark",
-    "username": "mark",
-    "password": "mark"
+    "currency": "USD",
+    "plugin": "ilp-plugin-mock",
+    "options": {
+      "account": "http://usd-ledger.example/accounts/mark",
+      "username": "mark",
+      "password": "mark"
+    }
   },
   "eur-ledger.": {
-    "type": "mock",
-    "account": "http://eur-ledger.example/accounts/mark",
-    "username": "mark",
-    "password": "mark"
+    "currency": "EUR",
+    "plugin": "ilp-plugin-mock",
+    "options": {
+      "account": "http://eur-ledger.example/accounts/mark",
+      "username": "mark",
+      "password": "mark"
+    }
   },
   "cny-ledger.": {
-    "type": "mock",
-    "account": "http://cny-ledger.example/accounts/mark",
-    "username": "mark",
-    "password": "mark"
+    "currency": "CNY",
+    "plugin": "ilp-plugin-mock",
+    "options": {
+      "account": "http://cny-ledger.example/accounts/mark",
+      "username": "mark",
+      "password": "mark"
+    }
   }
 }

--- a/test/ilpQuoterSpec.js
+++ b/test/ilpQuoterSpec.js
@@ -23,34 +23,46 @@ describe('ILPQuoter', function () {
 
   beforeEach(function * () {
     process.env.UNIT_TEST_OVERRIDE = '1'
-    process.env.CONNECTOR_CREDENTIALS = JSON.stringify({
+    process.env.CONNECTOR_LEDGERS = JSON.stringify({
       'localhost:3000.': {
-        type: 'mock',
-        host: 'https://localhost:3000',
-        account: 'https://localhost:3000/accounts/mark',
-        username: 'mark',
-        password: 'mark'
+        currency: 'USD',
+        plugin: 'ilp-plugin-mock',
+        options: {
+          host: 'https://localhost:3000',
+          account: 'https://localhost:3000/accounts/mark',
+          username: 'mark',
+          password: 'mark'
+        }
       },
       'localhost:3001.': {
-        type: 'mock',
-        host: 'https://localhost:3001',
-        account: 'https://localhost:3001/accounts/mark',
-        username: 'mark',
-        password: 'mark'
+        currency: 'EUR',
+        plugin: 'ilp-plugin-mock',
+        options: {
+          host: 'https://localhost:3001',
+          account: 'https://localhost:3001/accounts/mark',
+          username: 'mark',
+          password: 'mark'
+        }
       },
       'localhost:4000.': {
-        type: 'mock',
-        host: 'https://localhost:4000',
-        account: 'https://localhost:4000/accounts/mark',
-        username: 'mark',
-        password: 'mark'
+        currency: 'USD',
+        plugin: 'ilp-plugin-mock',
+        options: {
+          host: 'https://localhost:4000',
+          account: 'https://localhost:4000/accounts/mark',
+          username: 'mark',
+          password: 'mark'
+        }
       },
       'localhost:4001.': {
-        type: 'mock',
-        host: 'https://localhost:4001',
-        account: 'https://localhost:4001/accounts/mark',
-        username: 'mark',
-        password: 'mark'
+        currency: 'EUR',
+        plugin: 'ilp-plugin-mock',
+        options: {
+          host: 'https://localhost:4001',
+          account: 'https://localhost:4001/accounts/mark',
+          username: 'mark',
+          password: 'mark'
+        }
       }
     })
 
@@ -73,8 +85,7 @@ describe('ILPQuoter', function () {
       infoCache: this.infoCache
     })
 
-    const getLedger = (currencyLedger) => currencyLedger.split('@')[1]
-    const testLedgers = _.flatMap(this.pairs, (pair) => _.map(pair, getLedger))
+    const testLedgers = _.flatMap(this.pairs, (pair) => pair)
 
     _.each(testLedgers, (ledgerUri) => {
       nock('http://' + ledgerUri).get('/')

--- a/test/paymentsSpec.js
+++ b/test/paymentsSpec.js
@@ -28,23 +28,35 @@ describe('Payments', function () {
       [
         'USD@mock.test1.',
         'EUR@mock.test2.'
+      ],
+      [
+        'EUR@mock.test2.',
+        'USD@mock.test1.'
       ]
     ]
     process.env.UNIT_TEST_OVERRIDE = '1'
-    process.env.CONNECTOR_CREDENTIALS = JSON.stringify({
+    process.env.CONNECTOR_LEDGERS = JSON.stringify({
       'mock.test1.': {
-        type: 'mock',
-        host: 'http://test1.mock',
-        account: 'xyz',
-        username: 'bob',
-        password: 'bob'
+        currency: 'USD',
+        plugin: 'ilp-plugin-mock',
+        options: {
+          type: 'mock',
+          host: 'http://test1.mock',
+          account: 'xyz',
+          username: 'bob',
+          password: 'bob'
+        }
       },
       'mock.test2.': {
-        type: 'mock',
-        host: 'http://test2.mock',
-        account: 'xyz',
-        username: 'bob',
-        password: 'bob'
+        currency: 'EUR',
+        plugin: 'ilp-plugin-mock',
+        options: {
+          type: 'mock',
+          host: 'http://test2.mock',
+          account: 'xyz',
+          username: 'bob',
+          password: 'bob'
+        }
       }
     })
     process.env.CONNECTOR_PAIRS = JSON.stringify(pairs)

--- a/test/routeBroadcasterSpec.js
+++ b/test/routeBroadcasterSpec.js
@@ -49,8 +49,8 @@ describe('RouteBroadcaster', function () {
 
     this.broadcaster = new RouteBroadcaster(this.tables, this.backend, this.core, this.infoCache, {
       tradingPairs: [
-        ['USD@' + ledgerA, 'EUR@' + ledgerB],
-        ['EUR@' + ledgerB, 'USD@' + ledgerA]
+        [ledgerA, ledgerB],
+        [ledgerB, ledgerA]
       ],
       minMessageWindow: 1,
       autoloadPeers: true,

--- a/test/routeBuilderSpec.js
+++ b/test/routeBuilderSpec.js
@@ -51,8 +51,16 @@ describe('RouteBuilder', function () {
     }])
 
     const ledgerCredentials = {}
-    ledgerCredentials[ledgerA] = {type: 'mock'}
-    ledgerCredentials[ledgerB] = {type: 'mock'}
+    ledgerCredentials[ledgerA] = {
+      currency: 'USD',
+      plugin: 'ilp-plugin-mock',
+      options: {}
+    }
+    ledgerCredentials[ledgerB] = {
+      currency: 'USD',
+      plugin: 'ilp-plugin-mock',
+      options: {}
+    }
     this.core = makeCore({
       config: {
         ledgerCredentials,


### PR DESCRIPTION
Removes `CONNECTOR_CREDENTIALS`, instead rolling those options into `CONNECTOR_LEDGERS`. Fixes a problem in the auto-generation of `CONNECTOR_PAIRS` which causes pairs to be generated in one direction only (would include `usd -> eur` but not `eur -> usd`). Updates the README to reflect these changes.