### PR TITLE
Fix: fix the deploy script

### DIFF
--- a/scripts/ci-deploy.sh
+++ b/scripts/ci-deploy.sh
@@ -3,7 +3,7 @@
 publishNpm() {
   # Push NPM package if not yet published
   mv npmrc-env .npmrc
-  if [ -z "$(npm info $(npm ls --depth=-1 2>/dev/null | head -1 | cut -f 1 -d " ") 2>/dev/null)" ]; then
+  if [ "$(npm info $(npm ls --depth=-1 2>/dev/null | head -1 | cut -f 1 -d " ") 2>/dev/null)" = "undefined" ]; then
     npm publish
   fi
 }


### PR DESCRIPTION
`npm info` prints `undefined` on a nonexistant version, not an empty string. This problem was preventing `ilp-connector` from publishing to npm.

This was likely a change between node 4 and node 6, introduced in https://github.com/interledger/js-ilp-connector/commit/6a4b7a8de955db79413ff1d2f79950b4a0269b2e . It would explain why the most recent version on npm is 10.0.3.